### PR TITLE
Add screenshot tool and Discord file upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,3 +73,7 @@ generated images locally:
 ```bash
 python agent_cli.py "青い空と白い雲の風景画"
 ```
+
+## Screenshot tool
+`capture_screenshot` saves the current screen to a PNG file. Combine it with
+`DiscordManager.send_file` to share images in chat.

--- a/discord_manager.py
+++ b/discord_manager.py
@@ -204,7 +204,7 @@ class DiscordManager:
         
         return events
     
-    async def send_message(self, channel_id: int, content: str, 
+    async def send_message(self, channel_id: int, content: str,
                           embed: Optional[discord.Embed] = None) -> Dict[str, Any]:
         """
         Send a message to a Discord channel.
@@ -233,6 +233,28 @@ class DiscordManager:
             
         except Exception as e:
             logger.error(f"Failed to send message: {e}")
+            return {"error": str(e)}
+
+    async def send_file(self, channel_id: int, file_path: str,
+                        content: str = "",
+                        embed: Optional[discord.Embed] = None) -> Dict[str, Any]:
+        """Send a file to a Discord channel."""
+        try:
+            channel = self.bot.get_channel(channel_id)
+            if not channel:
+                return {"error": f"Channel {channel_id} not found"}
+
+            file = discord.File(file_path)
+            message = await channel.send(content=content, embed=embed, file=file)
+
+            return {
+                "success": True,
+                "message_id": message.id,
+                "channel_id": channel_id,
+                "file_path": file_path,
+            }
+        except Exception as e:
+            logger.error(f"Failed to send file: {e}")
             return {"error": str(e)}
     
     async def get_channel_messages(self, channel_id: int, 

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,3 +24,4 @@ aio_pika
 textblob
 httpx<0.28
 uvicorn
+pyautogui

--- a/tests/test_tool_manager.py
+++ b/tests/test_tool_manager.py
@@ -216,3 +216,24 @@ async def test_media_describe_video(monkeypatch):
     result = await tm.media_describe_video("video.mp4")
     assert result["avg_color"] == [1.0, 2.0, 3.0]
 
+
+@pytest.mark.asyncio
+async def test_capture_screenshot(tmp_path, monkeypatch):
+    tm = ToolManager(db_path=":memory:")
+
+    import types
+    import sys
+
+    class DummyImage:
+        def save(self, path):
+            with open(path, "wb") as f:
+                f.write(b"data")
+
+    dummy_mod = types.SimpleNamespace(screenshot=lambda: DummyImage())
+    monkeypatch.setitem(sys.modules, "pyautogui", dummy_mod)
+
+    out_path = tmp_path / "shot.png"
+    result = await tm.capture_screenshot(str(out_path))
+    assert result == str(out_path)
+    assert out_path.exists()
+

--- a/tool_manager.py
+++ b/tool_manager.py
@@ -17,6 +17,7 @@ class ToolManager:
             "generate_image": self.generate_image,
             "simple_math": self.simple_math,
             "get_current_time": self.get_current_time,
+            "capture_screenshot": self.capture_screenshot,
         }
         self._agent = None  # 必要に応じてセット
 
@@ -65,6 +66,30 @@ class ToolManager:
         import datetime
         now = datetime.datetime.now()
         return f"現在の日時は {now.strftime('%Y-%m-%d %H:%M:%S')} です。"
+
+    async def capture_screenshot(self, output_path: str | None = None) -> str:
+        """Capture a screenshot of the current screen and save to a file."""
+        try:
+            import os
+            import tempfile
+            import pyautogui
+
+            if output_path is None:
+                fd, path = tempfile.mkstemp(suffix=".png")
+                os.close(fd)
+                output_path = path
+
+            loop = asyncio.get_running_loop()
+
+            def _capture(path: str) -> None:
+                img = pyautogui.screenshot()
+                img.save(path)
+
+            await loop.run_in_executor(None, _capture, output_path)
+            return output_path
+        except Exception as e:
+            logging.error(f"capture_screenshot error: {e}")
+            return f"エラー: スクリーンショットの取得に失敗しました - {e}"
 
     async def get_tools_schema(self) -> List[Dict[str, Any]]:
         return [
@@ -120,6 +145,18 @@ class ToolManager:
                 "function": {
                     "name": "get_current_time",
                     "description": "現在の日時を返します。",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {},
+                        "required": []
+                    },
+                },
+            },
+            {
+                "type": "function",
+                "function": {
+                    "name": "capture_screenshot",
+                    "description": "現在の画面をキャプチャして画像ファイルとして保存します。",
                     "parameters": {
                         "type": "object",
                         "properties": {},


### PR DESCRIPTION
## Summary
- add `capture_screenshot` tool to capture the current screen
- support sending files in `DiscordManager`
- document the screenshot tool in README
- include pyautogui in requirements
- test screenshot tool with monkeypatched pyautogui

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: parse_seek_time missing)*

------
https://chatgpt.com/codex/tasks/task_e_6884c43ddfdc8322b04f93fb1433e87d